### PR TITLE
Switch to proper dot notation dict

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ gogh
 Using the kolorz python interface to print colored output:
 
 ```python
-from kolorz import kolorz
+from kolorz import make_kolorz
 
-kl = kolorz()
+kl = make_kolorz()
 
 print(f"{kl.blue}This is some{kl.end} {kl.orange}output{kl.end}")
 ```
@@ -88,7 +88,7 @@ white
 By default, the colorscheme is set to `catppuccin mocha` but that can be changed to any of the colorschemes listed by `kolorz`. For example:
 
 ```python
-from kolorz import kolorz
+from kolorz import make_kolorz
 
 kl = kolorz("nord")
 
@@ -110,7 +110,7 @@ new_colors = {
     "white": (204, 208, 218),
 }
 
-kl = kolorz(custom=new_colors)
+kl = make_kolorz(custom=new_colors)
 
 print(f"{kl.blue}This is some{kl.end} {kl.orange}output{kl.end}")
 ```
@@ -120,15 +120,15 @@ print(f"{kl.blue}This is some{kl.end} {kl.orange}output{kl.end}")
 Adding or overriding a color
 
 ```python
-from kolorz import kolorz
+from kolorz import make_kolorz, make_kolor
 
-kl = kolorz()
+kl = make_kolorz()
 
 # Adding
-kl.set_color("rosewater", (245, 224, 220))
+kl.rosewater = make_kolor((245, 224, 220))
 
 # Overriding
-kl.set_color("blue", (137, 220, 235))
+kl.blue = make_kolor((137, 220, 235))
 
 print(f"{kl.rosewater}This is some{kl.end} {kl.blue}output{kl.end}")
 ```

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ By default, the colorscheme is set to `catppuccin mocha` but that can be changed
 ```python
 from kolorz import make_kolorz
 
-kl = kolorz("nord")
+kl = make_kolorz("nord")
 
 print(f"{kl.blue}This is some{kl.end} {kl.orange}output{kl.end}")
 ```

--- a/kolorz/__init__.py
+++ b/kolorz/__init__.py
@@ -1,1 +1,1 @@
-from kolorz.kolor import kolorz
+from kolorz.kolor import make_kolorz, make_kolor

--- a/kolorz/cli.py
+++ b/kolorz/cli.py
@@ -1,5 +1,5 @@
 from kolorz.colors import colors
-from kolorz.kolor import kolorz
+from kolorz.kolor import make_kolorz
 import random
 
 def kolor():
@@ -9,7 +9,7 @@ def kolor():
     print("Supported colorschemes: \n")
 
     for color, values in colors.items():
-        kol = kolorz(color)
+        kol = make_kolorz(color)
         col = random.choice(list(values.keys()))
         print(f"{getattr(kol, col)}{color}{kol.end}")
 

--- a/kolorz/kolor.py
+++ b/kolorz/kolor.py
@@ -3,39 +3,23 @@ A library to facilitate printing colored output to terminals
 """
 from kolorz.colors import colors
 from typing import Optional, Any
+from dotwiz import DotWiz
 
-class kolorz:
+def make_kolorz(colorscheme: str = "catppuccin mocha", custom: Optional[dict[Any, Any]] = None):
+
+    if custom is None:
+        theme = colors[colorscheme]
+    else:
+        theme = custom
+    
+    kolorz_dict = {color_name: make_kolor(color_value) for color_name, color_value in theme.items()}
+    kolorz_dict['end'] = "\033[0m"
+
+    return DotWiz(kolorz_dict)
+
+def make_kolor(color: tuple) -> str:
     """
-    The koolest klass you've ever seen
+    Wraps the rgp tuple in an escape sequence 
     """
-    def __init__(self, colorscheme: str = "catppuccin mocha", custom: Optional[dict[Any, Any]] = None) -> None:
-        
-        if custom is None:
-            self.colorscheme = colorscheme
-            theme = colors[colorscheme]
-        else:
-            self.colorscheme = "custom"
-            theme = custom
-
-        for key, val in theme.items():
-            setattr(self, key, self._assign_color(val)) 
-            
-        self.end = "\033[0m"
-
-    def __str__(self) -> str:
-        return f"Current Colorscheme: {self.colorscheme}"        
-
-    def _assign_color(self, color: tuple) -> str:
-        """
-        Wraps the rgp tuple in an escape sequence 
-        """
-        return f"\033[38;2;{color[0]};{color[1]};{color[2]}m"
-
-    def set_color(self, color: str, color_values: tuple) -> None:
-        """
-        overrides an existing color. 
-
-        If the specified color does not exist, makes a new one
-        """
-        setattr(self, color, self._assign_color(color_values))
+    return f"\033[38;2;{color[0]};{color[1]};{color[2]}m"
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,8 +1,45 @@
-package = []
+[[package]]
+name = "dotwiz"
+version = "0.3.1"
+description = "DotWiz is a blazing fast dict subclass that enables accessing (nested) keys in dot notation."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pyheck = "0.1.5"
+
+[[package]]
+name = "pyheck"
+version = "0.1.5"
+description = "Python bindings for heck, the Rust case conversion library"
+category = "main"
+optional = false
+python-versions = ">=3.7"
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "ce2aa767160f871dd3652615ba0a0dceb7733d62eb8cb4665b87f30a562e3adf"
+content-hash = "9d4ec19e8ce2412641f30d9f209b78023d39b3445187bdb87541a7d57e9e36f3"
 
 [metadata.files]
+dotwiz = [
+    {file = "dotwiz-0.3.1-py2.py3-none-any.whl", hash = "sha256:b10e0b0d2c641fcb9547885431f53f8fe0b42cab878b074a2bf52d85a6f18a3d"},
+    {file = "dotwiz-0.3.1.tar.gz", hash = "sha256:b5b4a2aeb122185325c5a88ee7407fc595ca2979fdfc78dacec62b8ed619fbda"},
+]
+pyheck = [
+    {file = "pyheck-0.1.5-cp37-abi3-macosx_10_7_x86_64.whl", hash = "sha256:44caf2b7a49d71fdeb0469e9f35886987ad815a8638b3c5b5c83f351d6aed413"},
+    {file = "pyheck-0.1.5-cp37-abi3-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:316a842b94beff6e59a97dbcc590e9be92a932e59126b0faa9ac750384f27eaf"},
+    {file = "pyheck-0.1.5-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b6169397395ff041f056bfb36c1957a788a1cd7cb967a927fcae7917ff1b6aa"},
+    {file = "pyheck-0.1.5-cp37-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e9d101e1c599227280e34eeccab0414246e70a91a1cabb4c4868dca284f2be7d"},
+    {file = "pyheck-0.1.5-cp37-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:69d6509138909df92b2f2f837518dca118ef08ae3c804044ae511b81b7aecb4d"},
+    {file = "pyheck-0.1.5-cp37-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8ce4a2e1b4778051b8f31183e321a034603f3957b6e95cf03bf5f231c8ea3066"},
+    {file = "pyheck-0.1.5-cp37-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:69387b70d910637ab6dc8dc378c8e0b4037cee2c51a9c6f64ce5331b010f5de3"},
+    {file = "pyheck-0.1.5-cp37-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0fb50b7d899d2a583ec2ac291b8ec2afb10f0e32c4ac290148d3da15927787f8"},
+    {file = "pyheck-0.1.5-cp37-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:aa8dfd0883212f8495e0bae6eb6ea670c56f9b197b5fe6fb5cae9fd5ec56fb7c"},
+    {file = "pyheck-0.1.5-cp37-abi3-musllinux_1_2_i686.whl", hash = "sha256:e9ba36060abc55127c3813de398b4013c05be6118cfae3cfa3d978f7b4c84dea"},
+    {file = "pyheck-0.1.5-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:64201a6d213bec443aeb33f66c60cea61aaf6257e48a19159ac69a5afad4768e"},
+    {file = "pyheck-0.1.5-cp37-abi3-win32.whl", hash = "sha256:1501fcfd15f7c05c6bfe38915f5e514ac95fc63e945f7d8b089d30c1b8fdb2c5"},
+    {file = "pyheck-0.1.5-cp37-abi3-win_amd64.whl", hash = "sha256:e519f80a0ef87a8f880bfdf239e396e238dcaed34bec1ea7ef526c4873220e82"},
+    {file = "pyheck-0.1.5.tar.gz", hash = "sha256:5c9fe372d540c5dbcb76bf062f951d998d0e14c906c842a52f1cd5de208e183a"},
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.9"
+dotwiz = "^0.3.1"
 
 [tool.poetry.scripts]
 kolorz = "kolorz.cli:kolor"


### PR DESCRIPTION
- Use the `dotwiz` package to allow proper dot.notation without linting errors